### PR TITLE
Update and rename virtual.host to virtual.host.conf

### DIFF
--- a/build/travis/apache/virtual.host.conf
+++ b/build/travis/apache/virtual.host.conf
@@ -6,7 +6,7 @@
 
     <Directory %basedir%/web>
         DirectoryIndex app.php
-        Options -Indexes FollowSymLinks SymLinksifOwnerMatch
+        Options -Indexes +FollowSymLinks +SymLinksifOwnerMatch
         AllowOverride All
         Allow from All
     </Directory>

--- a/build/travis/scripts/apache2-configure.sh
+++ b/build/travis/scripts/apache2-configure.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-VHOSTNAME="virtual.host"
+VHOSTNAME="virtual.host.conf"
 if [ "$1" ]
 then
     VHOSTNAME="$1"

--- a/build/travis/scripts/apache2-vhost.sh
+++ b/build/travis/scripts/apache2-vhost.sh
@@ -4,7 +4,7 @@ BASEDIR=$(dirname $0)
 BASEDIR=$(readlink -f "$BASEDIR/..")
 ROOTDIR=$(readlink -f "$BASEDIR/../..")
 
-VHOSTNAME="virtual.host"
+VHOSTNAME="virtual.host.conf"
 if [ "$1" ]
 then
     VHOSTNAME="$1"
@@ -16,7 +16,7 @@ then
     DOCROOT="$2"
 fi
 
-CONFIGFILE="$BASEDIR/apache/virtual.host"
+CONFIGFILE="$BASEDIR/apache/virtual.host.conf"
 if [ "$3" ]
 then
     CONFIGFILE="$3"


### PR DESCRIPTION
- changes relating to Apache2.2 vs Apache2.4 configuration
  - .conf file extension is required for Apache2.4 on trusty
- fix the vhost options which require all Options to start with + or -